### PR TITLE
Only run fossa on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,16 +8,12 @@ jobs:
   build:
     <<: *defaults
     steps:
-      - run: |
-          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash
       - checkout
       - restore_cache:
           keys:
             - v1-dependencies-{{ checksum "package.json" }}
             - v1-dependencies-
       - run: npm install
-      - run: fossa init
-      - run: fossa analyze
       - save_cache:
           paths:
             - node_modules
@@ -29,6 +25,19 @@ jobs:
           paths:
             - node_modules
             - packages/*/node_modules
+  license_test:
+    <<: *defaults
+    steps:
+      - run: |
+          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+            - v1-dependencies-
+      - run: npm install
+      - run: fossa init
+      - run: fossa analyze
 
   integration_test:
     <<: *defaults
@@ -52,6 +61,10 @@ workflows:
   pipeline:
     jobs:
       - build
+      - license_test:
+          filters:
+            branches:
+              only: master
       - integration_test:
           requires:
             - build


### PR DESCRIPTION
We are currently hitting the below error when running fossa on pull request branches. This is seen at #37.

Error during upload: could not upload: could not send API HTTP request: Post https://app.fossa.com/api/builds/custom?branch=pull%2F37&locator=custom%2Bgit%40github.com%3Alaconiajs%2Flaconia.git%24a14711c4e1a0f56b11842e224db8d3a6d91cf238&managedBuild=true&title=git%40github.com%3Alaconiajs%2Flaconia.git&v=0.7.29: unexpected EOF