### PR TITLE
Handle the headers property being null

### DIFF
--- a/packages/laconia-event/src/apigateway/ApiGatewayInputHeaders.js
+++ b/packages/laconia-event/src/apigateway/ApiGatewayInputHeaders.js
@@ -1,8 +1,10 @@
 module.exports = class ApiGatewayInputHeaders {
   constructor(eventHeaders) {
-    Object.entries(eventHeaders).forEach(([headerName, headerValue]) => {
-      this[headerName.toLowerCase()] = headerValue;
-    });
+    if (eventHeaders) {
+      Object.entries(eventHeaders).forEach(([headerName, headerValue]) => {
+        this[headerName.toLowerCase()] = headerValue;
+      });
+    }
 
     const handler = {
       get: (target, prop) => {

--- a/packages/laconia-event/test/apigateway/ApiGatewayInputHeaders.spec.js
+++ b/packages/laconia-event/test/apigateway/ApiGatewayInputHeaders.spec.js
@@ -29,4 +29,9 @@ describe("ApiGatewayInputHeaders", () => {
     const inputHeaders = new ApiGatewayInputHeaders({});
     expect(inputHeaders.toString()).toEqual("[object Object]");
   });
+
+  it("should should accept test events from API Gateway web UI", async () => {
+    const inputHeaders = new ApiGatewayInputHeaders(null);
+    expect(inputHeaders).toEqual(expect.anything());
+  });
 });


### PR DESCRIPTION
When a Lambda is called from the API Gateway test function in the UI, the `event.headers` property is `null` causing the following error:
```
    TypeError: Cannot convert undefined or null to object
        at Function.entries (<anonymous>)

      1 | module.exports = class ApiGatewayInputHeaders {
      2 |   constructor(eventHeaders) {
    > 3 |     Object.entries(eventHeaders).forEach(([headerName, headerValue]) => {
        |            ^
      4 |       this[headerName.toLowerCase()] = headerValue;
      5 |     });
      6 |
```