### PR TITLE
Fix type test, npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1035,32 +1035,6 @@
       "dev": true,
       "requires": {
         "p-wait-for": "^3.1.0"
-      },
-      "dependencies": {
-        "p-finally": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-          "dev": true
-        },
-        "p-timeout": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.0.0.tgz",
-          "integrity": "sha512-HKUsVzU+2A+CcItUxgZ4Q1th5Hh2DHtSsh7gLTMkrL8Ki4Ss736nFp+yqb9M/ZKSKb5il0IXeLzBmUqD3k3mzQ==",
-          "dev": true,
-          "requires": {
-            "p-finally": "^1.0.0"
-          }
-        },
-        "p-wait-for": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/p-wait-for/-/p-wait-for-3.1.0.tgz",
-          "integrity": "sha512-0Uy19uhxbssHelu9ynDMcON6BmMk6pH8551CvxROhiz3Vx+yC4RqxjyIDk2V4ll0g9177RKT++PK4zcV58uJ7A==",
-          "dev": true,
-          "requires": {
-            "p-timeout": "^3.0.0"
-          }
-        }
       }
     },
     "@lerna/add": {
@@ -4760,10 +4734,13 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-      "dev": true
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.1.0",
@@ -10421,11 +10398,29 @@
       "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
       "dev": true
     },
+    "p-timeout": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.1.0.tgz",
+      "integrity": "sha512-C27DYI+tCroT8J8cTEyySGydl2B7FlxrGNF5/wmMbl1V+jeehUCzEE/BVgzRebdm2K3ZitKOKx8YbdFumDyYmw==",
+      "dev": true,
+      "requires": {
+        "p-finally": "^1.0.0"
+      }
+    },
     "p-try": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
       "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
       "dev": true
+    },
+    "p-wait-for": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-wait-for/-/p-wait-for-3.1.0.tgz",
+      "integrity": "sha512-0Uy19uhxbssHelu9ynDMcON6BmMk6pH8551CvxROhiz3Vx+yC4RqxjyIDk2V4ll0g9177RKT++PK4zcV58uJ7A==",
+      "dev": true,
+      "requires": {
+        "p-timeout": "^3.0.0"
+      }
     },
     "p-waterfall": {
       "version": "1.0.0",

--- a/packages/laconia-config/test/types/index.ts
+++ b/packages/laconia-config/test/types/index.ts
@@ -3,4 +3,4 @@ import config from "../../src/index";
 
 const app = async (input: number, { someSecret }: { someSecret: string }) => {};
 
-exports.handler = laconia(app).register(config.envVarInstaces());
+exports.handler = laconia(app).register(config.envVarInstances());

--- a/packages/laconia-test-helper/package-lock.json
+++ b/packages/laconia-test-helper/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@laconia/test-helper",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
The config package had the wrong spelling of `envVarInstances`.