### PR TITLE
[laconia-config] Only call .convertMultiple if values object is not empty

### DIFF
--- a/packages/laconia-config/src/EnvVarConfigFactory.js
+++ b/packages/laconia-config/src/EnvVarConfigFactory.js
@@ -31,7 +31,10 @@ module.exports = class EnvVarConfigFactory extends EnvVarInstanceFactory {
     const conversionResults = await Promise.all(
       types.map(type => {
         const values = filterAndRemoveType(type, typedValues);
-        return this.converters[type].convertMultiple(values);
+        return (
+          Object.keys(values).length > 0 &&
+          this.converters[type].convertMultiple(values)
+        );
       })
     );
     return Object.assign({}, ...conversionResults);


### PR DESCRIPTION
As I was using the new `SecretsManagerConfigConverter`, I was getting the following AWS error:

```
 Failure: 1 validation error detected: Value '[]' at 'names' failed to satisfy constraint: Member must have length greater than or equal to 1
```

I had an env variable like:
```
LACONIA_CONFIG_TEST_API_KEY='secretsManager:dev/something'
```

And then I realized `SsmConfigConverter.convertMultiple` was being called with an empty object. This should fix it.