### PR TITLE
#120 register single dependency

### DIFF
--- a/packages/laconia-core/src/index.d.ts
+++ b/packages/laconia-core/src/index.d.ts
@@ -23,6 +23,11 @@ declare namespace laconia {
       factory: LaconiaFactory | LaconiaFactory[],
       options?: FactoryOptions
     ): LaconiaHandler;
+    set(
+      name: string,
+      factory: LaconiaFactory,
+      options?: FactoryOptions
+    ): LaconiaHandler;
   }
 }
 

--- a/packages/laconia-core/src/laconia.js
+++ b/packages/laconia-core/src/laconia.js
@@ -41,6 +41,14 @@ module.exports = app => {
       }
       return laconia;
     },
+    set: (name, factory, options = {}) => {
+      checkFunction("register", factory);
+      laconia.register(
+        async laconiaContext => ({ [name]: await factory(laconiaContext) }),
+        options
+      );
+      return laconia;
+    },
     postProcessor: postProcessor => {
       checkFunction("postProcessor", postProcessor);
       laconiaContext.registerPostProcessor(postProcessor);

--- a/packages/laconia-core/test/types/index.ts
+++ b/packages/laconia-core/test/types/index.ts
@@ -32,6 +32,8 @@ laconia(app)
       enabled: false,
       maxAge: 1000
     }
-  });
+  })
+  .set("someKey", () => "value")
+  .set("someKey", () => "value", {});
 
 laconia(adapter(app)).register(() => ({ someKey: "value" }));


### PR DESCRIPTION
Add method `.set(name, factory, options)` as alias for `.register(factory, options)`

```javascript
exports.handler = laconia(kinesis(app))
  .set("orderStream", ({env}) => myOwnFactory(env.ORDER_STREAM_NAME) );
```