### PR TITLE
Create SSM secret automatically - partially solve #389

### DIFF
--- a/packages/laconia-acceptance-test/serverless.yml
+++ b/packages/laconia-acceptance-test/serverless.yml
@@ -221,6 +221,14 @@ functions:
 
 resources:
   Resources:
+    ApiKeySSM:
+      Type: AWS::SSM::Parameter
+      Properties:
+        Description: place-order api key
+        Name: /${self:custom.fullName}/apikey
+        Tier: Standard
+        Type: String
+        Value: supersecretkey
     S3Tracker:
       Type: AWS::S3::Bucket
       Properties:


### PR DESCRIPTION
#389 - Ease the run of manual acceptance tests:

- Create SSM secret automatically.