### PR TITLE
Update acceptance test runtime from node8 to node10

### DIFF
--- a/packages/laconia-acceptance-test/acceptance-test/acceptance.spec.js
+++ b/packages/laconia-acceptance-test/acceptance-test/acceptance.spec.js
@@ -36,6 +36,17 @@ const deleteAllItems = async (tableName, keyName, keyValue) => {
   }
 };
 
+const storeApiKey = () => {
+  return new AWS.SSM()
+    .putParameter({
+      Name: `/${prefix}/apikey`,
+      Type: "SecureString",
+      Value: "supersecretkey",
+      Overwrite: true
+    })
+    .promise();
+};
+
 const createOrder = (restaurantId, total) => ({
   restaurantId,
   customer: {
@@ -157,6 +168,7 @@ describe("order flow", () => {
     );
   });
 
+  beforeAll(() => storeApiKey());
   beforeAll(async () => {
     orderUrl = await getOrderUrl();
   });

--- a/packages/laconia-acceptance-test/package.json
+++ b/packages/laconia-acceptance-test/package.json
@@ -23,12 +23,12 @@
     "url": "https://github.com/laconiajs/laconia.git"
   },
   "scripts": {
-    "test": "npm run test:8",
-    "test:8": "AWS_REGION=eu-west-1 NODE_VERSION=node8 jest /acceptance-test",
-    "deploy": "npm run deploy:8",
-    "deploy:8": "AWS_REGION=eu-west-1 NODE_RUNTIME=nodejs8.10 NODE_VERSION=node8 sls deploy",
-    "remove": "npm run remove:8",
-    "remove:8": "AWS_REGION=eu-west-1 NODE_RUNTIME=nodejs8.10 NODE_VERSION=node8 sls remove"
+    "test": "npm run test:10",
+    "test:10": "AWS_REGION=eu-west-1 NODE_VERSION=node10 jest /acceptance-test",
+    "deploy": "npm run deploy:10",
+    "deploy:10": "AWS_REGION=eu-west-1 NODE_RUNTIME=nodejs10.x NODE_VERSION=node10 sls deploy",
+    "remove": "npm run remove:10",
+    "remove:10": "AWS_REGION=eu-west-1 NODE_RUNTIME=nodejs10.x NODE_VERSION=node10 sls remove"
   },
   "dependencies": {
     "@laconia/adapter": "^1.8.0",

--- a/packages/laconia-acceptance-test/serverless.yml
+++ b/packages/laconia-acceptance-test/serverless.yml
@@ -12,8 +12,8 @@ package:
 
 provider:
   name: aws
-  runtime: ${env:NODE_RUNTIME, 'nodejs8.10' }
-  stage: ${env:NODE_VERSION, 'node8' }
+  runtime: ${env:NODE_RUNTIME, 'nodejs10.x' }
+  stage: ${env:NODE_VERSION, 'node10' }
   region: ${env:AWS_REGION, 'eu-west-1'}
   tracing: true
   apiGateway:

--- a/packages/laconia-acceptance-test/serverless.yml
+++ b/packages/laconia-acceptance-test/serverless.yml
@@ -68,6 +68,7 @@ custom:
   remover:
     buckets:
       - ${self:custom.trackerBucketName}
+      - ${self:custom.totalOrderBucketName}
   s3Sync:
     - bucketName: ${self:custom.restaurantBucketName}
       localDir: src/resources


### PR DESCRIPTION
This PR also create the required apikey parameter automatically

The parameter is being created in acceptance.spec.js because CloudFormation does not support SecretString creation, obviously due to security reason.
In our case, as this is not really a secret, it is safe for us to have the plain text secret in our test.

This closes #418