### PR TITLE
Add accountId to buckets name

### DIFF
--- a/packages/laconia-acceptance-test/serverless.yml
+++ b/packages/laconia-acceptance-test/serverless.yml
@@ -56,11 +56,12 @@ provider:
     LACONIA_TEST_SPY_BUCKET: ${self:custom.trackerBucketName}
 
 custom:
+  accountId: ${file(./src/sts.js):getAccountId}
   fullName: ${self:service}-${self:provider.stage}
-  trackerBucketName: ${self:custom.fullName}-tracker
-  totalOrderBucketName: ${self:custom.fullName}-total-order
+  trackerBucketName: ${self:custom.fullName}-${self:custom.accountId}-tracker
+  totalOrderBucketName: ${self:custom.fullName}-${self:custom.accountId}-total-order
   userEmailQueueName: ${self:custom.fullName}-user-email-queue
-  restaurantBucketName: ${self:custom.fullName}-restaurant
+  restaurantBucketName: ${self:custom.fullName}-${self:custom.accountId}-restaurant
   orderEventsStreamName: ${self:custom.fullName}-order-events
   restaurantNotificationTopicName: ${self:custom.fullName}-restaurant-notification
   orderDynamoDbBatchTableName: ${self:custom.fullName}-order

--- a/packages/laconia-acceptance-test/src/sts.js
+++ b/packages/laconia-acceptance-test/src/sts.js
@@ -1,0 +1,7 @@
+const { STS } = require("aws-sdk");
+const sts = new STS();
+
+exports.getAccountId = async () => {
+  const { Account } = await sts.getCallerIdentity().promise();
+  return Account;
+};


### PR DESCRIPTION
#389 - Ease the run of manual acceptance tests

I coulnd't not use #{AWS::AccountId} because sync plugin doesn't works well with pseudo-parameters plugin.