### PR TITLE
fix(laconia-event): only try to read body as Buffer if it isn't falsy

### DIFF
--- a/packages/laconia-event/src/apigateway/parseWebSocket.js
+++ b/packages/laconia-event/src/apigateway/parseWebSocket.js
@@ -2,6 +2,6 @@ const getBody = require("./getBody");
 const tryParseJson = require("../tryParseJson");
 
 module.exports = event => {
-  const body = getBody(event);
+  const body = event.body && getBody(event);
   return tryParseJson(body);
 };

--- a/packages/laconia-event/test/apigateway/parseWebsocket.spec.js
+++ b/packages/laconia-event/test/apigateway/parseWebsocket.spec.js
@@ -48,5 +48,10 @@ describe("parseWebSocket", () => {
       const body = parseWebSocket(event);
       expect(body).toEqual("foobar");
     });
+
+    it("should return null as is", () => {
+      const body = parseWebSocket({});
+      expect(body).toEqual(undefined);
+    });
   });
 });


### PR DESCRIPTION
WebSocket: Error 500 when using adapter for $connect route #49
The problem is create a buffer of event.body (undefined).

fix #49