### PR TITLE
feat(laconia-config): Parse integers and floats from LACONIA_CONFIG_ env variables

### DIFF
--- a/packages/laconia-acceptance-test/acceptance-test/acceptance.spec.js
+++ b/packages/laconia-acceptance-test/acceptance-test/acceptance.spec.js
@@ -221,11 +221,12 @@ describe("order flow", () => {
 
   describe("happy path", () => {
     it("should store all placed orders in Order Table", async () => {
-      Object.keys(orderMap).forEach(async orderId => {
+      // Use for...of to properly await promises
+      for (const orderId of Object.keys(orderMap)) {
         const savedOrder = await orderRepository.find(orderId);
         expect(savedOrder).toEqual(expect.objectContaining(orderMap[orderId]));
         expect(savedOrder.orderId).toEqual(orderId);
-      });
+      }
     });
 
     it("should invoke send email lambda, which is coming from the chain of place-order, notify-restaurant, fake-restaurant, accept-order, and notify-user", async () => {

--- a/packages/laconia-config/src/FloatConfigConverter.js
+++ b/packages/laconia-config/src/FloatConfigConverter.js
@@ -1,8 +1,6 @@
 const validateAndParseFloat = (key, val) => {
   if (val.trim() === "") {
-    throw new Error(
-      `Passed config:float "${key}" is empty.`
-    );
+    throw new Error(`Passed config:float "${key}" is empty.`);
   }
   const parsedVal = parseFloat(val);
   if (isNaN(val)) {

--- a/packages/laconia-config/src/FloatConfigConverter.js
+++ b/packages/laconia-config/src/FloatConfigConverter.js
@@ -1,9 +1,6 @@
 const validateAndParseFloat = (key, val) => {
-  if (val.trim() === "") {
-    throw new Error(`Passed config:float "${key}" is empty.`);
-  }
   const parsedVal = parseFloat(val);
-  if (isNaN(val)) {
+  if (isNaN(parsedVal)) {
     throw new Error(
       `Passed config:float "${key}" = "${val}" is not a valid float.`
     );

--- a/packages/laconia-config/src/FloatConfigConverter.js
+++ b/packages/laconia-config/src/FloatConfigConverter.js
@@ -1,6 +1,8 @@
+const floatRegex = /[^0-9.]/g;
+
 const validateAndParseFloat = (key, val) => {
   const parsedVal = parseFloat(val);
-  if (isNaN(parsedVal)) {
+  if (isNaN(parsedVal) || val !== val.replace(floatRegex, "")) {
     throw new Error(
       `Passed config:float "${key}" = "${val}" is not a valid float.`
     );

--- a/packages/laconia-config/src/FloatConfigConverter.js
+++ b/packages/laconia-config/src/FloatConfigConverter.js
@@ -1,0 +1,8 @@
+module.exports = class FloatConfigConverter {
+  convertMultiple(values) {
+    return Object.keys(values).reduce((acc, key) => {
+      acc[key] = parseFloat(values[key]);
+      return acc;
+    }, {});
+  }
+};

--- a/packages/laconia-config/src/FloatConfigConverter.js
+++ b/packages/laconia-config/src/FloatConfigConverter.js
@@ -1,8 +1,8 @@
-const floatRegex = /[^0-9.]/g;
+const floatRegex = /[^0-9.-]/g;
 
 const validateAndParseFloat = (key, val) => {
   const parsedVal = parseFloat(val);
-  if (isNaN(parsedVal) || val !== val.replace(floatRegex, "")) {
+  if (isNaN(parsedVal) || val.match(floatRegex)) {
     throw new Error(
       `Passed config:float "${key}" = "${val}" is not a valid float.`
     );

--- a/packages/laconia-config/src/FloatConfigConverter.js
+++ b/packages/laconia-config/src/FloatConfigConverter.js
@@ -1,7 +1,23 @@
+const validateAndParseFloat = (key, val) => {
+  if (val.trim() === "") {
+    throw new Error(
+      `Passed config:float "${key}" is empty.`
+    );
+  }
+  const parsedVal = parseFloat(val);
+  if (isNaN(val)) {
+    throw new Error(
+      `Passed config:float "${key}" = "${val}" is not a valid float.`
+    );
+  }
+
+  return parsedVal;
+};
+
 module.exports = class FloatConfigConverter {
   convertMultiple(values) {
     return Object.keys(values).reduce((acc, key) => {
-      acc[key] = parseFloat(values[key]);
+      acc[key] = validateAndParseFloat(key, values[key]);
       return acc;
     }, {});
   }

--- a/packages/laconia-config/src/IntegerConfigConverter.js
+++ b/packages/laconia-config/src/IntegerConfigConverter.js
@@ -1,7 +1,18 @@
+const validateAndParseInt = (key, val) => {
+  const parsedVal = parseInt(val, 10);
+  if (isNaN(val)) {
+    throw new Error(
+      `Passed config:integer "${key}" = "${val}" is not a valid integer.`
+    );
+  }
+
+  return parsedVal;
+};
+
 module.exports = class IntegerConfigConverter {
   convertMultiple(values) {
     return Object.keys(values).reduce((acc, key) => {
-      acc[key] = parseInt(values[key], 10);
+      acc[key] = validateAndParseInt(key, values[key]);
       return acc;
     }, {});
   }

--- a/packages/laconia-config/src/IntegerConfigConverter.js
+++ b/packages/laconia-config/src/IntegerConfigConverter.js
@@ -1,6 +1,8 @@
+const integerRegex = /\D/g;
+
 const validateAndParseInt = (key, val) => {
   const parsedVal = parseInt(val, 10);
-  if (isNaN(parsedVal)) {
+  if (isNaN(parsedVal) || val !== val.replace(integerRegex, "")) {
     throw new Error(
       `Passed config:integer "${key}" = "${val}" is not a valid integer.`
     );

--- a/packages/laconia-config/src/IntegerConfigConverter.js
+++ b/packages/laconia-config/src/IntegerConfigConverter.js
@@ -1,0 +1,8 @@
+module.exports = class IntegerConfigConverter {
+  convertMultiple(values) {
+    return Object.keys(values).reduce((acc, key) => {
+      acc[key] = parseInt(values[key], 10);
+      return acc;
+    }, {});
+  }
+};

--- a/packages/laconia-config/src/IntegerConfigConverter.js
+++ b/packages/laconia-config/src/IntegerConfigConverter.js
@@ -1,6 +1,6 @@
 const validateAndParseInt = (key, val) => {
   const parsedVal = parseInt(val, 10);
-  if (isNaN(val)) {
+  if (isNaN(parsedVal)) {
     throw new Error(
       `Passed config:integer "${key}" = "${val}" is not a valid integer.`
     );

--- a/packages/laconia-config/src/IntegerConfigConverter.js
+++ b/packages/laconia-config/src/IntegerConfigConverter.js
@@ -1,8 +1,8 @@
-const integerRegex = /\D/g;
+const integerRegex = /[^0-9-]/g;
 
 const validateAndParseInt = (key, val) => {
   const parsedVal = parseInt(val, 10);
-  if (isNaN(parsedVal) || val !== val.replace(integerRegex, "")) {
+  if (isNaN(parsedVal) || val.match(integerRegex)) {
     throw new Error(
       `Passed config:integer "${key}" = "${val}" is not a valid integer.`
     );

--- a/packages/laconia-config/test/EnvVarConfigFactory.spec.js
+++ b/packages/laconia-config/test/EnvVarConfigFactory.spec.js
@@ -61,6 +61,8 @@ describe("EnvVarConfigFactory", () => {
     let ssmConverter;
     let booleanConverter;
     let secretsManagerConverter;
+    let integerConverter;
+    let floatConverter;
 
     beforeEach(() => {
       ssmConverter = {
@@ -76,16 +78,27 @@ describe("EnvVarConfigFactory", () => {
       secretsManagerConverter = {
         convertMultiple: jest.fn().mockResolvedValue({ apikey: "secretApiKey" })
       };
+      integerConverter = {
+        convertMultiple: jest.fn().mockResolvedValue({ port: 8080 })
+      };
+      floatConverter = {
+        convertMultiple: jest.fn().mockResolvedValue({ taxRate: 1.093 })
+      };
+
       const env = {
         LACONIA_CONFIG_SECRET: "ssm:/path/to/secret",
         LACONIA_CONFIG_PASSWORD: "ssm:/path/to/password",
         LACONIA_CONFIG_ENABLE_LOGGING: "boolean:no",
-        LACONIA_CONFIG_ENABLE_FEATURE: "boolean:yes"
+        LACONIA_CONFIG_ENABLE_FEATURE: "boolean:yes",
+        LACONIA_CONFIG_PORT: "integer:8080",
+        LACONIA_CONFIG_TAX_RATE: "float:1.093"
       };
       const converters = {
         ssm: ssmConverter,
         boolean: booleanConverter,
-        secretsManager: secretsManagerConverter
+        secretsManager: secretsManagerConverter,
+        integer: integerConverter,
+        float: floatConverter
       };
       configFactory = new EnvVarConfigFactory(env, converters);
     });
@@ -99,6 +112,12 @@ describe("EnvVarConfigFactory", () => {
       expect(booleanConverter.convertMultiple).toHaveBeenCalledWith({
         enableLogging: "no",
         enableFeature: "yes"
+      });
+      expect(integerConverter.convertMultiple).toHaveBeenCalledWith({
+        port: "8080"
+      });
+      expect(floatConverter.convertMultiple).toHaveBeenCalledWith({
+        taxRate: "1.093"
       });
     });
 
@@ -126,7 +145,9 @@ describe("EnvVarConfigFactory", () => {
         secret: "mysecret",
         password: "password",
         enableLogging: false,
-        enableFeature: true
+        enableFeature: true,
+        port: 8080,
+        taxRate: 1.093
       });
     });
   });

--- a/packages/laconia-config/test/FloatConfigConverter.spec.js
+++ b/packages/laconia-config/test/FloatConfigConverter.spec.js
@@ -11,6 +11,14 @@ describe("FloatConfigConverter", () => {
       });
       expect(instances).toHaveProperty("tax", 80.8);
     });
+
+    it("returns NaN when not a float", async () => {
+      configConverter = new FloatConfigConverter();
+      const instances = await configConverter.convertMultiple({
+        tax: "someString"
+      });
+      expect(instances).toHaveProperty("tax", NaN);
+    });
   });
 
   describe("when there is multiple env vars set", () => {
@@ -18,10 +26,12 @@ describe("FloatConfigConverter", () => {
       const configConverter = new FloatConfigConverter();
       const floats = await configConverter.convertMultiple({
         taxRate: "80.80",
-        splitTest: "0.56"
+        splitTest: "0.56",
+        nonFloat: "not a float"
       });
       expect(floats).toHaveProperty("taxRate", 80.8);
       expect(floats).toHaveProperty("splitTest", 0.56);
+      expect(floats).toHaveProperty("nonFloat", NaN);
     });
   });
 });

--- a/packages/laconia-config/test/FloatConfigConverter.spec.js
+++ b/packages/laconia-config/test/FloatConfigConverter.spec.js
@@ -47,10 +47,10 @@ describe("FloatConfigConverter", () => {
       const configConverter = new FloatConfigConverter();
       const floats = await configConverter.convertMultiple({
         taxRate: "80.80",
-        splitTest: "0.56"
+        splitTest: "-0.56"
       });
       expect(floats).toHaveProperty("taxRate", 80.8);
-      expect(floats).toHaveProperty("splitTest", 0.56);
+      expect(floats).toHaveProperty("splitTest", -0.56);
     });
 
     it("throws an error when one value is not a float", async () => {

--- a/packages/laconia-config/test/FloatConfigConverter.spec.js
+++ b/packages/laconia-config/test/FloatConfigConverter.spec.js
@@ -21,14 +21,13 @@ describe("FloatConfigConverter", () => {
       ).toThrow(`Passed config:float "tax" = "foo" is not a valid float.`);
     });
 
-    // Thoughts on this?
     it("throws an error when value is an empty string", async () => {
       configConverter = new FloatConfigConverter();
       await expect(() =>
         configConverter.convertMultiple({
           tax: ""
         })
-      ).toThrow(`Passed config:float "tax" is empty.`);
+      ).toThrow(`Passed config:float "tax" = "" is not a valid float.`);
     });
   });
 

--- a/packages/laconia-config/test/FloatConfigConverter.spec.js
+++ b/packages/laconia-config/test/FloatConfigConverter.spec.js
@@ -29,6 +29,17 @@ describe("FloatConfigConverter", () => {
         })
       ).toThrow(`Passed config:float "tax" = "" is not a valid float.`);
     });
+
+    it("throws an error when value has invalid characters", async () => {
+      configConverter = new FloatConfigConverter();
+      await expect(() =>
+        configConverter.convertMultiple({
+          retryRate: "0.43b"
+        })
+      ).toThrow(
+        `Passed config:float "retryRate" = "0.43b" is not a valid float.`
+      );
+    });
   });
 
   describe("when there is multiple env vars set", () => {

--- a/packages/laconia-config/test/FloatConfigConverter.spec.js
+++ b/packages/laconia-config/test/FloatConfigConverter.spec.js
@@ -12,12 +12,23 @@ describe("FloatConfigConverter", () => {
       expect(instances).toHaveProperty("tax", 80.8);
     });
 
-    it("returns NaN when not a float", async () => {
+    it("throws an error when value is not a float", async () => {
       configConverter = new FloatConfigConverter();
-      const instances = await configConverter.convertMultiple({
-        tax: "someString"
-      });
-      expect(instances).toHaveProperty("tax", NaN);
+      await expect(() =>
+        configConverter.convertMultiple({
+          tax: "foo"
+        })
+      ).toThrow(`Passed config:float "tax" = "foo" is not a valid float.`);
+    });
+
+    // Thoughts on this?
+    it("throws an error when value is an empty string", async () => {
+      configConverter = new FloatConfigConverter();
+      await expect(() =>
+        configConverter.convertMultiple({
+          tax: ""
+        })
+      ).toThrow(`Passed config:float "tax" is empty.`);
     });
   });
 
@@ -26,12 +37,24 @@ describe("FloatConfigConverter", () => {
       const configConverter = new FloatConfigConverter();
       const floats = await configConverter.convertMultiple({
         taxRate: "80.80",
-        splitTest: "0.56",
-        nonFloat: "not a float"
+        splitTest: "0.56"
       });
       expect(floats).toHaveProperty("taxRate", 80.8);
       expect(floats).toHaveProperty("splitTest", 0.56);
-      expect(floats).toHaveProperty("nonFloat", NaN);
+    });
+
+    it("throws an error when one value is not a float", async () => {
+      const configConverter = new FloatConfigConverter();
+      await expect(() =>
+        configConverter.convertMultiple({
+          taxRate: "80.80",
+          splitTest: "0.56",
+          nonFloat: "not a float",
+          anotherInvalid: "also not a float"
+        })
+      ).toThrow(
+        `Passed config:float "nonFloat" = "not a float" is not a valid float.`
+      );
     });
   });
 });

--- a/packages/laconia-config/test/FloatConfigConverter.spec.js
+++ b/packages/laconia-config/test/FloatConfigConverter.spec.js
@@ -1,0 +1,27 @@
+const FloatConfigConverter = require("../src/FloatConfigConverter");
+
+describe("FloatConfigConverter", () => {
+  describe("when there is one env var set", () => {
+    let configConverter;
+
+    it("converts a float value to a float", async () => {
+      configConverter = new FloatConfigConverter();
+      const instances = await configConverter.convertMultiple({
+        tax: "80.80"
+      });
+      expect(instances).toHaveProperty("tax", 80.8);
+    });
+  });
+
+  describe("when there is multiple env vars set", () => {
+    it("should return multiple instances", async () => {
+      const configConverter = new FloatConfigConverter();
+      const floats = await configConverter.convertMultiple({
+        taxRate: "80.80",
+        splitTest: "0.56"
+      });
+      expect(floats).toHaveProperty("taxRate", 80.8);
+      expect(floats).toHaveProperty("splitTest", 0.56);
+    });
+  });
+});

--- a/packages/laconia-config/test/IntegerConfigConverter.spec.js
+++ b/packages/laconia-config/test/IntegerConfigConverter.spec.js
@@ -31,6 +31,17 @@ describe("IntegerConfigConverter", () => {
         })
       ).toThrow(`Passed config:integer "port" = "" is not a valid integer.`);
     });
+
+    it("throws an error when value has invalid characters", async () => {
+      configConverter = new IntegerConfigConverter();
+      await expect(() =>
+        configConverter.convertMultiple({
+          retryAttempts: "3a"
+        })
+      ).toThrow(
+        `Passed config:integer "retryAttempts" = "3a" is not a valid integer.`
+      );
+    });
   });
 
   describe("when there is multiple env vars set", () => {

--- a/packages/laconia-config/test/IntegerConfigConverter.spec.js
+++ b/packages/laconia-config/test/IntegerConfigConverter.spec.js
@@ -11,6 +11,14 @@ describe("IntegerConfigConverter", () => {
       });
       expect(instances).toHaveProperty("port", 9999);
     });
+
+    it("returns NaN when not an integer", async () => {
+      configConverter = new IntegerConfigConverter();
+      const instances = await configConverter.convertMultiple({
+        port: "someString"
+      });
+      expect(instances).toHaveProperty("port", NaN);
+    });
   });
 
   describe("when there is multiple env vars set", () => {
@@ -18,10 +26,12 @@ describe("IntegerConfigConverter", () => {
       const configConverter = new IntegerConfigConverter();
       const integers = await configConverter.convertMultiple({
         port: "9999",
-        retryCount: "7"
+        retryCount: "7",
+        nonInt: "not an integer"
       });
       expect(integers).toHaveProperty("port", 9999);
       expect(integers).toHaveProperty("retryCount", 7);
+      expect(integers).toHaveProperty("nonInt", NaN);
     });
   });
 });

--- a/packages/laconia-config/test/IntegerConfigConverter.spec.js
+++ b/packages/laconia-config/test/IntegerConfigConverter.spec.js
@@ -22,6 +22,15 @@ describe("IntegerConfigConverter", () => {
         `Passed config:integer "port" = "someString" is not a valid integer.`
       );
     });
+
+    it("throws an error when value is empty", async () => {
+      configConverter = new IntegerConfigConverter();
+      await expect(() =>
+        configConverter.convertMultiple({
+          port: ""
+        })
+      ).toThrow(`Passed config:integer "port" = "" is not a valid integer.`);
+    });
   });
 
   describe("when there is multiple env vars set", () => {

--- a/packages/laconia-config/test/IntegerConfigConverter.spec.js
+++ b/packages/laconia-config/test/IntegerConfigConverter.spec.js
@@ -49,10 +49,10 @@ describe("IntegerConfigConverter", () => {
       const configConverter = new IntegerConfigConverter();
       const integers = await configConverter.convertMultiple({
         port: "9999",
-        retryCount: "7"
+        retryCount: "-7"
       });
       expect(integers).toHaveProperty("port", 9999);
-      expect(integers).toHaveProperty("retryCount", 7);
+      expect(integers).toHaveProperty("retryCount", -7);
     });
 
     it("throws an error when one value is not an integer", async () => {

--- a/packages/laconia-config/test/IntegerConfigConverter.spec.js
+++ b/packages/laconia-config/test/IntegerConfigConverter.spec.js
@@ -1,0 +1,27 @@
+const IntegerConfigConverter = require("../src/IntegerConfigConverter");
+
+describe("IntegerConfigConverter", () => {
+  describe("when there is one env var set", () => {
+    let configConverter;
+
+    it("converts an integer value to an integer", async () => {
+      configConverter = new IntegerConfigConverter();
+      const instances = await configConverter.convertMultiple({
+        port: "9999"
+      });
+      expect(instances).toHaveProperty("port", 9999);
+    });
+  });
+
+  describe("when there is multiple env vars set", () => {
+    it("should return multiple instances", async () => {
+      const configConverter = new IntegerConfigConverter();
+      const integers = await configConverter.convertMultiple({
+        port: "9999",
+        retryCount: "7"
+      });
+      expect(integers).toHaveProperty("port", 9999);
+      expect(integers).toHaveProperty("retryCount", 7);
+    });
+  });
+});

--- a/packages/laconia-config/test/IntegerConfigConverter.spec.js
+++ b/packages/laconia-config/test/IntegerConfigConverter.spec.js
@@ -12,12 +12,15 @@ describe("IntegerConfigConverter", () => {
       expect(instances).toHaveProperty("port", 9999);
     });
 
-    it("returns NaN when not an integer", async () => {
+    it("throws an error when value is not an integer", async () => {
       configConverter = new IntegerConfigConverter();
-      const instances = await configConverter.convertMultiple({
-        port: "someString"
-      });
-      expect(instances).toHaveProperty("port", NaN);
+      await expect(() =>
+        configConverter.convertMultiple({
+          port: "someString"
+        })
+      ).toThrow(
+        `Passed config:integer "port" = "someString" is not a valid integer.`
+      );
     });
   });
 
@@ -26,12 +29,25 @@ describe("IntegerConfigConverter", () => {
       const configConverter = new IntegerConfigConverter();
       const integers = await configConverter.convertMultiple({
         port: "9999",
-        retryCount: "7",
-        nonInt: "not an integer"
+        retryCount: "7"
       });
       expect(integers).toHaveProperty("port", 9999);
       expect(integers).toHaveProperty("retryCount", 7);
-      expect(integers).toHaveProperty("nonInt", NaN);
+    });
+
+    it("throws an error when one value is not an integer", async () => {
+      const configConverter = new IntegerConfigConverter();
+      await expect(() =>
+        configConverter.convertMultiple({
+          port: "9999",
+          retryCount: "7",
+          notValid: "someString",
+          // It throws an error as soon as one value is NaN
+          anotherNonValid: "anotherString"
+        })
+      ).toThrow(
+        `Passed config:integer "notValid" = "someString" is not a valid integer.`
+      );
     });
   });
 });


### PR DESCRIPTION
This adds an integer converter and float converter when parking `LACONIA_CONFIG_` environment variables (#542).

- [x] Add LACONIA_CONFIG_PORT: integer:8080 to env to be interpreted by laconia-config as parseInt(8080);
- [x] Add LACONIA_CONFIG_TAX: float:80.80 to env to be interpreted by laconia-config as parseFloat(80.08);
- [ ] Update documentation and examples with new features [laconiajs/website/issues/8](https://github.com/laconiajs/website/issues/8)

**Note:** There was a `.forEach` with an async callback in the acceptance test that I changed to a `for..of` loop in order to properly await the promises.