### PR TITLE
chore(deps-dev): bump npm-package-json-lint to 4.6.0 in package.json

### DIFF
--- a/.npmpackagejsonlintignore
+++ b/.npmpackagejsonlintignore
@@ -1,1 +1,0 @@
-node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -13068,9 +13068,9 @@
       }
     },
     "npm-package-json-lint": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-4.5.1.tgz",
-      "integrity": "sha512-U+9tIPglZHsc8uO19nVXn8XMWe0GN+73vi+pv/qX4kuZ/aGOYyBpLFVuTEnFm3KzDNUCx5gacPew92iic+Lsig==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-4.6.0.tgz",
+      "integrity": "sha512-opoykADMeyGN2UuvypIYpysUXO4wdAYc8DPklO86kxF1YfxHnTXdEzm0K7BGE5CbEu6lweELQgvFej53din5xg==",
       "dev": true,
       "requires": {
         "ajv": "^6.11.0",
@@ -13085,7 +13085,7 @@
         "log-symbols": "^3.0.0",
         "meow": "^6.0.0",
         "plur": "^3.1.1",
-        "semver": "^7.0.0",
+        "semver": "^7.1.2",
         "slash": "^3.0.0",
         "strip-json-comments": "^3.0.1"
       },
@@ -13316,9 +13316,9 @@
           "dev": true
         },
         "meow": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-6.0.0.tgz",
-          "integrity": "sha512-x4rYsjigPBDAxY+BGuK83YLhUIqui5wYyZoqb6QJCUOs+0fiYq+i/NV4Jt8OgIfObZFxG9iTyvLDu4UTohGTFw==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-6.0.1.tgz",
+          "integrity": "sha512-kxGTFgT/b7/oSRSQsJ0qsT5IMU+bgZ1eAdSA3kIV7onkW0QWo/hL5RbGlMfvBjHJKPE1LaPX0kdecYFiqYWjUw==",
           "dev": true,
           "requires": {
             "@types/minimist": "^1.2.0",
@@ -13478,9 +13478,9 @@
           }
         },
         "semver": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.2.tgz",
-          "integrity": "sha512-BJs9T/H8sEVHbeigqzIEo57Iu/3DG6c4QoqTfbQB3BPA4zgzAomh/Fk9E7QtjWQ8mx2dgA9YCfSF4y9k9bHNpQ==",
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
+          "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==",
           "dev": true
         },
         "slash": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:all": "npm run test && npm run test:integration && npm run test:acceptance",
     "test:jslint": "eslint ./ --ignore-path .gitignore",
     "test:types": "tsc -p tsconfig.json && tsc -p tsconfig-js.json",
-    "test:packagelint": "lerna exec npmPkgJsonLint -- --quiet -c \\$LERNA_ROOT_PATH/.npmpackagejsonlintrc.json -i \\$LERNA_ROOT_PATH/.npmpackagejsonlintignore .",
+    "test:packagelint": "lerna exec npmPkgJsonLint -- --quiet -c \\$LERNA_ROOT_PATH/.npmpackagejsonlintrc.json .",
     "deploy-acceptance": "lerna exec --scope @laconia/acceptance-test npm run deploy",
     "remove-acceptance": "lerna exec --scope @laconia/acceptance-test npm run remove",
     "acceptance-test": "lerna exec --scope @laconia/acceptance-test npm run test",
@@ -60,7 +60,7 @@
     "jest-extended": "^0.11.1",
     "lerna": "^3.10.8",
     "lodash": "^4.17.5",
-    "npm-package-json-lint": "^4.0.2",
+    "npm-package-json-lint": "^4.6.0",
     "prettier": "^1.16.4",
     "typescript": "^3.4.5"
   },


### PR DESCRIPTION
There was a bug with `npm-package-json-lint` where sub-package node_modules weren't being ignored. That has since been fixed, so this removes the unnecessary `.npmpackagejsonlintignore`.

See: https://github.com/tclindner/npm-package-json-lint/issues/168#issuecomment-581205438