### PR TITLE
Check error message in API gateway error handler

### DIFF
--- a/packages/laconia-adapter-api/src/ApiGatewayNameMappingErrorConverter.js
+++ b/packages/laconia-adapter-api/src/ApiGatewayNameMappingErrorConverter.js
@@ -6,7 +6,7 @@ const getMappingEntries = mappings =>
 const getMappingResponse = (mappings, error) => {
   let mappingResponse = {};
   for (const [errorRegex, mapping] of getMappingEntries(mappings)) {
-    if (error.name.match(errorRegex)) {
+    if (error.name.match(errorRegex) || error.message.match(errorRegex)) {
       mappingResponse = mapping(error);
       break;
     }

--- a/packages/laconia-adapter-api/test/ApiGatewayNameMappingErrorConverter.spec.js
+++ b/packages/laconia-adapter-api/test/ApiGatewayNameMappingErrorConverter.spec.js
@@ -184,4 +184,39 @@ describe("ApiGatewayErrorConverter", () => {
       expect(response).toHaveStatusCode(500);
     });
   });
+
+  describe("when mapping happens by the error message", () => {
+    const errorConverter = new ApiGatewayErrorConverter({
+      mappings: {
+        "Validation.*": () => ({ statusCode: 400 }),
+        "Other.*": () => ({ statusCode: 500 })
+      }
+    });
+
+    it("should match based on the error name", async () => {
+      const error = new Error("boom");
+      error.name = "ValidationError";
+
+      const response = await errorConverter.convert(error);
+      expect(response).toContainBody("boom");
+      expect(response).toHaveStatusCode(400);
+    });
+
+    it("should match based on the error message", async () => {
+      const error = new Error("Other validation error");
+
+      const response = await errorConverter.convert(error);
+      expect(response).toContainBody("Other validation error");
+      expect(response).toHaveStatusCode(500);
+    });
+
+    it("error name should take precedence", async () => {
+      const error = new Error("Other validation error");
+      error.name = "ValidationError";
+
+      const response = await errorConverter.convert(error);
+      expect(response).toContainBody("Other validation error");
+      expect(response).toHaveStatusCode(400);
+    });
+  });
 });


### PR DESCRIPTION
Some libraries just return with the built-in `Error` class, so it would be nice to filter based on the error message too.

Check if `error.message` matches the errorRegex.