### PR TITLE
Basic implementation of route adapter for adapter-api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ typings/
 
 # Serverless directories
 .serverless
+
+# IntelliJ
+.idea

--- a/packages/laconia-adapter-api/src/ApiGatewayRouteAdapter.js
+++ b/packages/laconia-adapter-api/src/ApiGatewayRouteAdapter.js
@@ -1,0 +1,32 @@
+const { res } = require("@laconia/event").apigateway;
+
+module.exports = class ApiGatewayRouteAdapter {
+  constructor(routeMappings) {
+    this.routeMappings = routeMappings;
+  }
+
+  matchRoute(path, route) {
+    const routeWithForwardSlash = route.startsWith("/") ? route : `/${route}`;
+
+    if (routeWithForwardSlash.endsWith("*")) {
+      return path.startsWith(route.replace("*", ""));
+    }
+    return routeWithForwardSlash === path;
+  }
+
+  findApp(path) {
+    return Object.entries(this.routeMappings)
+      .filter(routeMapping => this.matchRoute(path, routeMapping[0]))
+      .map(routeMapping => routeMapping[1])[0];
+  }
+
+  async handle(event, laconiaContext) {
+    const app = this.findApp(event.path);
+
+    return app ? app(event, laconiaContext) : res({}, 404);
+  }
+
+  toFunction() {
+    return this.handle.bind(this);
+  }
+};

--- a/packages/laconia-adapter-api/src/createApiGatewayAdapter.js
+++ b/packages/laconia-adapter-api/src/createApiGatewayAdapter.js
@@ -13,6 +13,7 @@ const createInputConverter = inputType => {
     : new ApiGatewayParamsInputConverter();
 };
 
+// TODO typo!
 const createApiAgatewayAdapter = ({
   inputType = "body",
   functional = true,

--- a/packages/laconia-adapter-api/src/createRouteAdapter.js
+++ b/packages/laconia-adapter-api/src/createRouteAdapter.js
@@ -1,0 +1,9 @@
+const ApiGatewayRouteAdapter = require("./ApiGatewayRouteAdapter");
+
+// right now just accept string paths, not methods (get, post)
+const createRouteAdapter = ({ mappings, functional = true } = {}) => {
+  const adapter = new ApiGatewayRouteAdapter(mappings);
+  return functional ? adapter.toFunction() : adapter;
+};
+
+module.exports = createRouteAdapter;

--- a/packages/laconia-adapter-api/src/index.d.ts
+++ b/packages/laconia-adapter-api/src/index.d.ts
@@ -1,4 +1,4 @@
-import { AdapterFactory } from "@laconia/core";
+import {Adapter, AdapterFactory} from "@laconia/core";
 import { apigateway as eventApiGateway } from "@laconia/event";
 
 declare interface ErrorResponse {
@@ -25,9 +25,13 @@ declare namespace apigateway {
     errorMappings?: ErrorMappings | Map<string, ErrorMapping>;
     responseAdditionalHeaders?: eventApiGateway.ApiGatewayOutputHeaders;
   }
+  interface RouteOptions {
+      mappings: Record<string, Adapter<any>>
+  }
 
   function apigateway(options?: AdapterFactoryOptions): AdapterFactory<any>;
   function webSocket(): AdapterFactory<any>;
+  function route(options: RouteOptions): Adapter<any>;
 }
 
 export = apigateway;

--- a/packages/laconia-adapter-api/src/index.js
+++ b/packages/laconia-adapter-api/src/index.js
@@ -1,5 +1,7 @@
 const createApiGatewayAdapter = require("./createApiGatewayAdapter");
 const createWebSocketAdapter = require("./createWebSocketAdapter");
+const routeAdapter = require("./createRouteAdapter");
 
 exports.apigateway = createApiGatewayAdapter;
 exports.webSocket = createWebSocketAdapter;
+exports.routing = routeAdapter;

--- a/packages/laconia-adapter-api/test/ApiGatewayRouteAdapter.spec.js
+++ b/packages/laconia-adapter-api/test/ApiGatewayRouteAdapter.spec.js
@@ -1,0 +1,81 @@
+const ApiGatewayRouteAdapter = require("../src/ApiGatewayRouteAdapter");
+
+describe("ApiGatewayRouteAdapter", () => {
+  let event;
+  let routeMappings;
+  let constructorArgs;
+  let laconiaContext;
+
+  beforeEach(() => {
+    const firstApp = jest.fn();
+    const secondApp = jest.fn();
+    const thirdApp = jest.fn();
+
+    firstApp.mockResolvedValue({ status: "first" });
+    secondApp.mockResolvedValue({ status: "second" });
+    thirdApp.mockResolvedValue({ status: "third" });
+
+    routeMappings = {
+      "/example/path": firstApp,
+      "/example/asterisk/*": secondApp,
+      "no/initial/slash": thirdApp
+    };
+    constructorArgs = [routeMappings];
+    laconiaContext = { laconia: "context" };
+  });
+
+  it("should call the app corresponding to the exact path", async () => {
+    event = {
+      foo: "event",
+      path: "/example/path"
+    };
+
+    const adapter = new ApiGatewayRouteAdapter(...constructorArgs);
+    const result = await adapter.handle(event, laconiaContext);
+
+    expect(result).toEqual(expect.objectContaining({ status: "first" }));
+  });
+
+  it("should call the app corresponding to the path with an asterisk", async () => {
+    event = {
+      foo: "event",
+      path: "/example/asterisk/123456"
+    };
+
+    const adapter = new ApiGatewayRouteAdapter(...constructorArgs);
+    const result = await adapter.handle(event, laconiaContext);
+
+    expect(result).toEqual(expect.objectContaining({ status: "second" }));
+  });
+
+  it("should call the app corresponding to the path with a missing initial forward slash", async () => {
+    event = {
+      foo: "event",
+      path: "/no/initial/slash"
+    };
+
+    const adapter = new ApiGatewayRouteAdapter(...constructorArgs);
+    const result = await adapter.handle(event, laconiaContext);
+
+    expect(result).toEqual(expect.objectContaining({ status: "third" }));
+  });
+
+  it("should return a 404 if no path is found", async () => {
+    event = {
+      foo: "event",
+      path: "/fake/path"
+    };
+
+    const adapter = new ApiGatewayRouteAdapter(...constructorArgs);
+    const result = await adapter.handle(event, laconiaContext);
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        statusCode: 404,
+        body: "{}",
+        isBase64Encoded: false,
+        headers: { "Content-Type": "application/json; charset=utf-8" }
+      })
+    );
+  });
+});

--- a/packages/laconia-adapter-api/test/createRouteAdapter.spec.js
+++ b/packages/laconia-adapter-api/test/createRouteAdapter.spec.js
@@ -1,0 +1,22 @@
+const createRouteAdapter = require("../src/createRouteAdapter");
+
+describe("createRouteAdapter", () => {
+  it("returns an adapter function", () => {
+    const adapter = createRouteAdapter();
+
+    expect(adapter).toBeFunction();
+  });
+
+  it("is created with given mappings", () => {
+    const app = jest.fn();
+
+    const adapter = createRouteAdapter({
+      mappings: { "example/path": app },
+      functional: false
+    });
+
+    expect(adapter.routeMappings).toEqual({
+      "example/path": app
+    });
+  });
+});


### PR DESCRIPTION
See https://github.com/laconiajs/laconia/issues/764

Unit tests run. Also tried it locally in a project and it worked.

This is a simple implementation: no matching on http method and string matching is limited (does allow asterisks at the end but nothing else). But perhaps sufficient for a first version.

Let me know what you think! If it's ok for now, I can also create a PR for the website documentation.