### PR TITLE
add handling for undefined input body

### DIFF
--- a/packages/laconia-event/src/apigateway/ApiGatewayEvent.js
+++ b/packages/laconia-event/src/apigateway/ApiGatewayEvent.js
@@ -6,7 +6,7 @@ module.exports = class ApiGatewayEvent {
     const apiGatewayEvent = new ApiGatewayEvent();
     apiGatewayEvent.headers = new ApiGatewayInputHeaders(event.headers);
     apiGatewayEvent.body =
-      event.body === null
+      event.body === null || event.body === undefined
         ? null
         : parseRequestBody(event, apiGatewayEvent.headers);
     apiGatewayEvent.params = Object.assign(

--- a/packages/laconia-event/test/apigateway/ApiGatewayEvent.spec.js
+++ b/packages/laconia-event/test/apigateway/ApiGatewayEvent.spec.js
@@ -37,6 +37,12 @@ describe("ApiGatewayEvent", () => {
     expect(apiGatewayEvent.body).toEqual(null);
   });
 
+  it("should not attempt to parse body when its undefined", async () => {
+    event.body = undefined;
+    const apiGatewayEvent = await ApiGatewayEvent.fromRaw(event);
+    expect(apiGatewayEvent.body).toEqual(null);
+  });
+
   it("should convert pathParameters into params", async () => {
     event.pathParameters = { pathParam1: "pathParam" };
     const apiGatewayEvent = await ApiGatewayEvent.fromRaw(event);


### PR DESCRIPTION
There's a small [bug in the adapter-api](https://github.com/laconiajs/laconia/blob/4bcb1161e4fde1b44e7a5258883c3d734a169a4f/packages/laconia-event/src/apigateway/ApiGatewayEvent.js#L9) and it fails when the request body is undefined (it tries to parse undefined)

I've added some tests and checks to handle request bodies that are undefined