### PR TITLE
Reorder function definitions

### DIFF
--- a/packages/laconia-acceptance-test/src/accept-order.js
+++ b/packages/laconia-acceptance-test/src/accept-order.js
@@ -3,9 +3,10 @@ const laconia = require("@laconia/core");
 const { req, res } = require("@laconia/event").apigateway;
 const KinesisOrderStream = require("./KinesisOrderStream");
 
-const instances = ({ env }) => ({
-  orderStream: new KinesisOrderStream(env.ORDER_STREAM_NAME)
-});
+const app = async (id, { orderStream }) => {
+  await orderStream.send({ eventType: "accepted", orderId: id });
+  return { status: "ok" };
+};
 
 const withCors = next => async (...args) => {
   const response = await next(...args);
@@ -24,9 +25,8 @@ const adapter = app =>
     }
   });
 
-const app = async (id, { orderStream }) => {
-  await orderStream.send({ eventType: "accepted", orderId: id });
-  return { status: "ok" };
-};
+const instances = ({ env }) => ({
+  orderStream: new KinesisOrderStream(env.ORDER_STREAM_NAME)
+});
 
 exports.handler = laconia(adapter(app)).register(instances);


### PR DESCRIPTION
This pull request demonstrates an example application of [Reading Order](https://tidyfirst.substack.com/p/reading-order) and [Cohesion Order](https://tidyfirst.substack.com/p/cohesion-order)

Reading Order: I defined what I expected to see first in this file, then opened it up. I expected to see the most important thing, which is the main logic first, and that logic is defined by the `app` function. That function is currently buried at the bottom of this file, so I pulled it to the top of the file for ease of reading.

Cohesion Order: I also noticed that the function `instances` should logically sit together when the IoC container is created, which is when the `register` method is called. Initially, the `instances` function was at the top of the file, it's moved to the bottom of the file for cohesion.